### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
 install:
   - "pip install -r requirements.txt"
   - "pip install -r requirements_dev.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
 install:
+  - "pip install -r requirements.txt"
   - "pip install -r requirements_dev.txt"
   - "pip install ."
 script:

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,8 @@ E.Sios API
 ==========
 
 Interact with e.sios API
+
+
+### Usage
+
+Ensure that `ESIOS_TOKEN` var exists and is exported for the working env.

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,7 @@ E.Sios API
 Interact with e.sios API
 
 
-### Usage
+Usage
+------
 
-Ensure that `ESIOS_TOKEN` var exists and is exported for the working env.
+Ensure that ``ESIOS_TOKEN`` var exists and is exported for the working env.

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ E.Sios API
 
 Interact with e.sios API
 
+http://esios.readthedocs.org/
 
 Usage
 ------

--- a/esios/__init__.py
+++ b/esios/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import    
+
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution(__name__).version

--- a/esios/__init__.py
+++ b/esios/__init__.py
@@ -4,4 +4,4 @@ try:
 except Exception as e:
     VERSION = 'unknown'
 
-from service import Esios
+from .service import Esios

--- a/esios/__init__.py
+++ b/esios/__init__.py
@@ -1,7 +1,7 @@
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution(__name__).version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'
 
 from service import Esios

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+libsaas

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='esios',
-    version='0.1.9',
+    version='0.1.10',
     packages=find_packages(),
     url='https://github.com/gisce/esios',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='esios',
-    version='0.1.10',
+    version='0.1.9',
     packages=find_packages(),
     url='https://github.com/gisce/esios',
     license='MIT',

--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -4,7 +4,7 @@ from expects import *
 from datetime import datetime, timedelta
 import calendar
 import zipfile
-from StringIO import StringIO
+from io import StringIO
 import json
 import os
 

--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -4,7 +4,7 @@ from expects import *
 from datetime import datetime, timedelta
 import calendar
 import zipfile
-from io import StringIO
+from io import BytesIO
 import json
 import os
 
@@ -41,7 +41,7 @@ with description('Liquicomun file'):
 
             e = Esios(self.token)
             res = e.liquicomun().download(start, end)
-            c = StringIO(res)
+            c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
             assert zf.namelist()[0][:2] in ('A1', 'A2')
@@ -54,7 +54,7 @@ with description('Liquicomun file'):
 
             e = Esios(self.token)
             res = e.liquicomun().download(start, end)
-            c = StringIO(res)
+            c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
             assert zf.namelist()[0][:2] in ('A3', 'C2')
@@ -67,7 +67,7 @@ with description('Liquicomun file'):
 
             e = Esios(self.token)
             res = e.liquicomun().download(start, end)
-            c = StringIO(res)
+            c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
             assert zf.namelist()[0][:2] in ('C6', 'C5')
@@ -80,7 +80,7 @@ with description('Liquicomun file'):
 
             e = Esios(self.token)
             res = e.liquicomun().download(start, end)
-            c = StringIO(res)
+            c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
             assert zf.namelist()[0][:2] in ('A7', 'C7', 'A6', 'C6', 'C5', 'A5')
@@ -98,7 +98,7 @@ with description('Liquicomun file'):
 #
 #             e = Esios(self.token)
 #             res = e.A1_liquicomun().download(start, end)
-#             c = StringIO(res)
+#             c = BytesIO(res)
 #             zf = zipfile.ZipFile(c)
 #             assert zf.testzip() is None
 #             assert zf.namelist()[0][:2] == 'A1'
@@ -116,7 +116,7 @@ with description('Liquicomun file'):
 #
 #             e = Esios(self.token)
 #             res = e.A2_liquicomun().download(start, end)
-#             c = StringIO(res)
+#             c = BytesIO(res)
 #             zf = zipfile.ZipFile(c)
 #             assert zf.testzip() is None
 #             assert zf.namelist()[0][:2] == 'A2'

--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -70,7 +70,7 @@ with description('Liquicomun file'):
             c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
-            assert zf.namelist()[0][:2] in ('C6', 'C5')
+            assert zf.namelist()[0][:2] in ('A5', 'A6', 'C6', 'C5'), "Current namelist '{}'".format(zf.namelist()[0][:2])
 
         with it('should download C7,A7,C6,A6,C5 or A5 for a long time ago'):
             today = datetime.today() - timedelta(days=730)

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -32,7 +32,7 @@ with description('Indicators file'):
             assert isinstance(profile, ProfilePVPC20A)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
-                equal(u'Tarifa 2.0A (peaje por defecto)')
+                equal(u'Tarifa 2.0.A (peaje por defecto)')
             )
             expect(data['indicator']['name']).to(
                 contain(u'Perfiles de consumo')


### PR DESCRIPTION
### Py3.6 compat

Provides py3.6 compatibility

It fixes imports, exceptions and the usage of StringIO lib -> io

Also, improves the specs to assert new types A5 and A6 for >1year

A requirements file with `libsaas` is also provided.

Finally, the new README includes info about the needed env vars (ESIOS_TOKEN) and where to find more information about the lib.

Tested over py27 and py36

Fix #15 Provide Py36 support