### PR TITLE
Disable C4, A6, A5, C5, A4 liquicomun file versions //PAUSED

### DIFF
--- a/esios/archives.py
+++ b/esios/archives.py
@@ -6,12 +6,12 @@ from libsaas.services import base
 
 from esios.utils import translate_param, serialize_param
 
-
 LIQUICOMUN_PRIORITY = [
-    'C7', 'A7', 'C6', 'A6', 'C5', 'A5', 'C4', 'A4', 'C3', 'A3', 'C2', 'A2',
+    'C7', 'A7', 'C6',
+    #'A6', 'C5', 'A5', 'C4', 'A4',    Disabled due to lack of Perd* files on the 2012-2017 tests
+    'C3', 'A3', 'C2', 'A2',
     'C1', 'A1'
 ]
-
 
 def parser_none(body, code, headers):
     return body

--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -70,9 +70,9 @@ with description('Liquicomun file'):
             c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
-            assert zf.namelist()[0][:2] in ('C4', 'A6', 'C6'), "Current namelist '{}'".format(zf.namelist()[0][:2])
+            assert zf.namelist()[0][:2] in ('A6', 'C6'), "Current namelist '{}'".format(zf.namelist()[0][:2])
 
-        with it('should download C7,A7,C6,A6,C5 or A5 for a long time ago'):
+        with it('should download C7,A7,C6,A6 for a long time ago'):
             today = datetime.today() - timedelta(days=730)
             start = datetime(today.year, today.month, 1)
             last_month_day = calendar.monthrange(start.year, start.month)[1]
@@ -83,7 +83,7 @@ with description('Liquicomun file'):
             c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
-            assert zf.namelist()[0][:2] in ('A7', 'C7', 'A6', 'C6', 'C5', 'A5')
+            assert zf.namelist()[0][:2] in ('A7', 'C7', 'A6', 'C6')
 
 # with description('A1 Liquicomun file'):
 #     with before.all:

--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -59,7 +59,7 @@ with description('Liquicomun file'):
             assert zf.testzip() is None
             assert zf.namelist()[0][:2] in ('A3', 'C2')
 
-        with it('should download C6 o C5 for a year ago'):
+        with it('should download C6 or C4 for a year ago'):
             today = datetime.today() - timedelta(days=730)
             start = datetime(today.year, today.month, 1)
             last_month_day = calendar.monthrange(start.year, start.month)[1]
@@ -70,7 +70,7 @@ with description('Liquicomun file'):
             c = BytesIO(res)
             zf = zipfile.ZipFile(c)
             assert zf.testzip() is None
-            assert zf.namelist()[0][:2] in ('A5', 'A6', 'C6', 'C5'), "Current namelist '{}'".format(zf.namelist()[0][:2])
+            assert zf.namelist()[0][:2] in ('C4', 'A6', 'C6'), "Current namelist '{}'".format(zf.namelist()[0][:2])
 
         with it('should download C7,A7,C6,A6,C5 or A5 for a long time ago'):
             today = datetime.today() - timedelta(days=730)


### PR DESCRIPTION
It disables C4, A6, A5, C5, A4 due to inconsistent appearing of the *_perd* files.

Fix #16