### PR TITLE
Add new ESIOS indicators

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -72,11 +72,11 @@ class pmh_pbf_free_RT3(Indicator):
     path = 'indicators/793'
 
 
-class pmh_tiempo_real_free_RT4(Indicator):
+class pmh_tiempo_real_free_RT6(Indicator):
     path = 'indicators/794'
 
 
-class pmh_intradiario_free_RT6(Indicator):
+class pmh_intradiario_free_RT4(Indicator):
     path = 'indicators/796'
 
 

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -68,8 +68,32 @@ class LinkBalanceMorocco(Indicator):
     path = 'indicators/10209'
 
 
+class pmh_pbf_free_RT3(Indicator):
+    path = 'indicators/793'
+
+
+class pmh_tiempo_real_free_RT4(Indicator):
+    path = 'indicators/794'
+
+
+class pmh_intradiario_free_RT6(Indicator):
+    path = 'indicators/796'
+
+
+class pmh_res_pot_sub_free_PS3(Indicator):
+    path = 'indicators/797'
+
+
+class pmh_bs_free_BS3(Indicator):
+    path = 'indicators/798'
+
+
 class mhpMeasuredDeviationsFree(Indicator):
     path = 'indicators/799'
+
+
+class pmh_saldo_desv_free_EXD(Indicator):
+    path = 'indicators/800'
 
 
 class mhpPO146BalanceFree(Indicator):

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -68,6 +68,10 @@ class LinkBalanceMorocco(Indicator):
     path = 'indicators/10209'
 
 
+class pmd_snp(Indicator):
+    path = 'indicators/573'
+
+
 class pmh_pbf_free_RT3(Indicator):
     path = 'indicators/793'
 

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -241,6 +241,76 @@ with description('Indicators file'):
                 contain(u'Saldo horario neto de interconexión con Marruecos telemedidas')
             )
 
+    with context('RT3 Free'):
+        with it('Returns pmh_pbf_free_RT3 instance'):
+            # 793
+            e = Esios(self.token)
+            profile = pmh_pbf_free_RT3(e)
+            assert isinstance(profile, pmh_pbf_free_RT3)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente restricciones PBF contrataci\xf3n libre')
+            )
+
+    with context('RT4 Free'):
+        with it('Returns pmh_tiempo_real_free_RT4 instance'):
+            # 794
+            e = Esios(self.token)
+            profile = pmh_tiempo_real_free_RT4(e)
+            assert isinstance(profile, pmh_tiempo_real_free_RT4)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente restricciones tiempo real contrataci\xf3n libre')
+            )
+
+    with context('RT6 Free'):
+        with it('Returns pmh_intradiario_free_RT6 instance'):
+            # 796
+            e = Esios(self.token)
+            profile = pmh_intradiario_free_RT6(e)
+            assert isinstance(profile, pmh_intradiario_free_RT6)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente restricciones intradiario contrataci\xf3n libre')
+            )
+
+    with context('PS3 Free'):
+        with it('Returns pmh_res_pot_sub_free_PS3 instance'):
+            # 797
+            e = Esios(self.token)
+            profile = pmh_res_pot_sub_free_PS3(e)
+            assert isinstance(profile, pmh_res_pot_sub_free_PS3)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente reserva de potencia adicional a subir contrataci\xf3n libre')
+            )
+
+    with context('BS3 Free'):
+        with it('Returns pmh_bs_free_BS3 instance'):
+            # 798
+            e = Esios(self.token)
+            profile = pmh_bs_free_BS3(e)
+            assert isinstance(profile, pmh_bs_free_BS3)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente banda secundaria contrataci\xf3n libre')
+            )
+
     with context('Medium Hourly Price Components'):
         with it('Returns mhpMeasuredDeviationsFree'):
             #799
@@ -254,6 +324,18 @@ with description('Indicators file'):
             )
             expect(data['indicator']['name']).to(
                 contain(u'Precio medio horario componente desvíos medidos contratación libre')
+            )
+        with it('Returns pmh_saldo_desv_free_EXD'):
+            #800
+            e = Esios(self.token)
+            profile = pmh_saldo_desv_free_EXD(e)
+            assert isinstance(profile, pmh_saldo_desv_free_EXD)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente saldo de desv\xedos contrataci\xf3n libre')
             )
         with it('Returns mhpPO146SaldoFree'):
             #802

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -205,7 +205,7 @@ with description('Indicators file'):
         ).hour).to(equal(0))
 
         # Commented till a month is complete
-        expect(len(data['indicator']['values']) / 5).to(equal(721))  # there are 5 different subsystems for each hour
+        expect(len(data['indicator']['values']) / 5).to(equal(720))  # there are 5 different subsystems for each hour
 
     with it('Returns a valid ProfilePVPC20TD'):
         e = Esios(self.token)
@@ -226,7 +226,7 @@ with description('Indicators file'):
         ).hour).to(equal(0))
 
         # Commented till a month is complete
-        expect(len(data['indicator']['values']) / 5).to(equal(721))  # there are 5 different subsystems for each hour
+        expect(len(data['indicator']['values']) / 5).to(equal(720))  # there are 5 different subsystems for each hour
 
     with context('LinkBalanceMorocco'):
         with it('Returns LinkBalanceMorocco instance'):

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -255,12 +255,12 @@ with description('Indicators file'):
                 contain(u'Precio medio horario componente restricciones PBF contrataci\xf3n libre')
             )
 
-    with context('RT4 Free'):
-        with it('Returns pmh_tiempo_real_free_RT4 instance'):
+    with context('RT6 Free'):
+        with it('Returns pmh_tiempo_real_free_RT6 instance'):
             # 794
             e = Esios(self.token)
-            profile = pmh_tiempo_real_free_RT4(e)
-            assert isinstance(profile, pmh_tiempo_real_free_RT4)
+            profile = pmh_tiempo_real_free_RT6(e)
+            assert isinstance(profile, pmh_tiempo_real_free_RT6)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
                 equal(u'Com. Libre')
@@ -269,12 +269,12 @@ with description('Indicators file'):
                 contain(u'Precio medio horario componente restricciones tiempo real contrataci\xf3n libre')
             )
 
-    with context('RT6 Free'):
-        with it('Returns pmh_intradiario_free_RT6 instance'):
+    with context('RT4 Free'):
+        with it('Returns pmh_intradiario_free_RT4 instance'):
             # 796
             e = Esios(self.token)
-            profile = pmh_intradiario_free_RT6(e)
-            assert isinstance(profile, pmh_intradiario_free_RT6)
+            profile = pmh_intradiario_free_RT4(e)
+            assert isinstance(profile, pmh_intradiario_free_RT4)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
                 equal(u'Com. Libre')

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -241,6 +241,20 @@ with description('Indicators file'):
                 contain(u'Saldo horario neto de interconexión con Marruecos telemedidas')
             )
 
+    with context('PMDSNP'):
+        with it('Returns pmd_snp instance'):
+            # 573
+            e = Esios(self.token)
+            profile = pmd_snp(e)
+            assert isinstance(profile, pmd_snp)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Precio medio demanda sistema')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio de la demanda en los SNP por sistema')
+            )
+
     with context('RT3 Free'):
         with it('Returns pmh_pbf_free_RT3 instance'):
             # 793


### PR DESCRIPTION
Add the following `ESIOS` components:
- **573**: PRECIO MEDIO DEMANDA EN LOS SNP POR SISTEMA
- **793**: PRECIO MEDIO HORARIO COMPONENTE RESTRICCIONES PBF
- **794**: PRECIO MEDIO HORARIO COMPONENTE RESTRICCIONES TIEMPO REAL
- **796**: PRECIO MEDIO HORARIO COMPONENTE RESTRICCIONES INTRADIARIO
- **797**: PRECIO MEDIO HORARIO COMPONENTE RESERVA POTENCIA A SUBIR
- **798**: PRECIO MEDIO HORARIO COMPONENTE BANDA SECUNDARIA
- **800**: PRECIO MEDIO HORARIO COMPONENTE SALDO DE DESVIOS