### PR TITLE
Se ha añadido el indicador de ESIOS para el Predio horario de mercado diario para contratación libre

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -117,6 +117,10 @@ class pmd_snp(Indicator):
     path = 'indicators/573'
 
 
+class pmh_pmm_free(Indicator):
+    path = 'indicators/792'
+
+
 class pmh_pbf_free_RT3(Indicator):
     path = 'indicators/793'
 

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -431,6 +431,20 @@ with description('Indicators file'):
                 equal(u'Coste de los desv\xedos medidos de menor producci\xf3n')
             )
 
+    with context('PMM Free'):
+        with it('Returns pmh_pmm_free instance'):
+            # 792
+            e = Esios(self.token)
+            profile = pmh_pmm_free(e)
+            assert isinstance(profile, pmh_pmm_free)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Com. Libre')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente mercado diario contrataci\xf3n libre')
+            )
+
     with context('RT3 Free'):
         with it('Returns pmh_pbf_free_RT3 instance'):
             # 793


### PR DESCRIPTION
Add the following `ESIOS` component:
- **792**: `PRECIO MEDIO HORARIO COMPONENTE MERCADO DIARIO CONTRATACIÓN LIBRE`