### PR TITLE
Se ha añadido el indicador de ESIOS para el Predio horario de mercado diario e intradiario del componente RDL 10/2022

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -235,3 +235,7 @@ class mhpEnergyBalanceInc(Indicator):
 
 class PriceEnergiaExcedentariaAutoconsumCompensacioSimplificada(Indicator):
     path = 'indicators/1739'
+
+
+class PriceMedioHorarioComponenteRDL102022Cur(Indicator):
+    path = 'indicators/1901'

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -795,3 +795,15 @@ with description('Indicators file'):
             expect(data['indicator']['name']).to(
                 contain(u'Precio medio horario componente incumplimiento energ\xeda de balance ')
             )
+        with it('Returns PriceMedioHorarioComponenteRDL102022Cur instance'):
+            #1901
+            e = Esios(self.token)
+            profile = PriceMedioHorarioComponenteRDL102022Cur(e)
+            assert isinstance(profile, PriceMedioHorarioComponenteRDL102022Cur)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Mecanismo de ajuste TOT_MAJ3')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidaci\xf3n con medidas ')
+            )


### PR DESCRIPTION
Add the following `ESIOS` component:
- **1901**: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidación con medidas comercializadores de referencia`