### PR TITLE
Actualizacion de nombre y descripción en algunos componentes de ESIOS

### DIFF
--- a/spec/archives_spec.py
+++ b/spec/archives_spec.py
@@ -293,20 +293,21 @@ with description('P48Cierre'):
 
         with it('Gets current month p48'):
             today = self.today
-            start = datetime(today.year, today.month, 1)
-            last_month_day = calendar.monthrange(today.year, today.month)[1]
-            end = datetime(today.year, today.month, today.day > 1 and today.day - 1 or 1)
+            if today.day not in (1, 2):
+                start = datetime(today.year, today.month, 1)
+                last_month_day = calendar.monthrange(today.year, today.month)[1]
+                end = datetime(today.year, today.month, today.day > 1 and today.day - 1 or 1)
 
-            res = P48Cierre(self.e).download(start, end)
+                res = P48Cierre(self.e).download(start, end)
 
-            c = BytesIO(res)
-            zf = zipfile.ZipFile(c)
-            assert zf.testzip() is None
-            expected_filenames = []
-            for day in range(0, today.day):
-                p48_day = start + relativedelta.relativedelta(days=day)
-                expected_filenames.append('p48cierre_{}.xml'.format(p48_day.strftime('%Y%m%d')))
+                c = BytesIO(res)
+                zf = zipfile.ZipFile(c)
+                assert zf.testzip() is None
+                expected_filenames = []
+                for day in range(0, today.day):
+                    p48_day = start + relativedelta.relativedelta(days=day)
+                    expected_filenames.append('p48cierre_{}.xml'.format(p48_day.strftime('%Y%m%d')))
 
-            assert len(zf.namelist()) == today.day - 1
-            for filename in zf.namelist():
+                assert len(zf.namelist()) == today.day - 1
+                for filename in zf.namelist():
                     assert filename in expected_filenames

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -805,7 +805,7 @@ with description('Indicators file'):
                 equal(u'Mecanismo de ajuste TOT_MAJ3')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidaci\xf3n con medidas ')
+                contain(u'Precio medio horario componente RD-L 10/2022 restricciones t\xe9cnicas y mercados de balance ')
             )
         with it('Returns PriceMedioHorarioMAJ3nocur instance'):
             # 1902
@@ -817,7 +817,7 @@ with description('Indicators file'):
                 equal(u'Mecanismo de ajuste CLI_MAJ3')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Precio medio horario componenSte RD-L 10/2022 mercado diario e intradiario - diferencia por liquidaci\xf3n con medidas contrataci\xf3n libre')
+                contain(u'Precio medio horario componente RD-L 10/2022 restricciones t\xe9cnicas y mercados de balance contrataci\xf3n libre')
             )
         with it('Returns PriceMedioHorarioMAJ3cur instance'):
             # 1903
@@ -829,7 +829,7 @@ with description('Indicators file'):
                 equal(u'Mecanismo de ajuste CUR_MAJ3')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidaci\xf3n con medidas comercializadores de referencia')
+                contain(u'Precio medio horario componente RD-L 10/2022 restricciones t\xe9cnicas y mercados de balance comercializadores de referencia')
             )
         with it('Returns PriceMedioHorarioAJOStotal instance'):
             # 1904
@@ -838,10 +838,10 @@ with description('Indicators file'):
             assert isinstance(profile, PriceMedioHorarioAJOStotal)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
-                equal(u'Mecanismo de ajuste CLI_AJOS')
+                equal(u'Mecanismo de ajuste TOT_AJOS')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Precio medio horario componente RD-L 10/2022 restricciones t\xe9cnicas y mercados de balance contrataci\xf3n libre')
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidaci\xf3n con medidas')
             )
         with it('Returns PriceMedioHorarioAJOSnocur instance'):
             # 1905
@@ -850,10 +850,10 @@ with description('Indicators file'):
             assert isinstance(profile, PriceMedioHorarioAJOSnocur)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
-                equal(u'Mecanismo de ajuste')
+                equal(u'Mecanismo de ajuste CLI_AJOS')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Mecanismo de ajuste contratacion libre')
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - dif. por liq. con medidas contrataci\xf3n libre')
             )
         with it('Returns PriceMedioHorarioAJOScur instance'):
             # 1906
@@ -865,5 +865,5 @@ with description('Indicators file'):
                 equal(u'Mecanismo de ajuste CUR_AJOS')
             )
             expect(data['indicator']['name']).to(
-                contain(u'Precio medio horario componente RD-L 10/2022 restricciones t\xe9cnicas y mercados de balance comercializadores de referencia')
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - dif. por liq. con med. comerc. referencia')
             )


### PR DESCRIPTION
## Objetivos

- Actualizar el nombre y la descripción de seis componentes de ESIOS que han cambiado recientemente su valor.
  - `1901`: `Precio medio horario componente RD-L 10/2022 restricciones técnicas y mercados de balance`
  - `1902`: `Precio medio horario componente RD-L 10/2022 restricciones técnicas y mercados de balance contratación libre`
  - `1903`: `Precio medio horario componente RD-L 10/2022 restricciones técnicas y mercados de balance comercializadores de referencia`
  - `1904`: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - diferencia por liquidación con medidas`
  - `1904`: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - dif. por liq. con medidas contratación libre`
  - `1904`: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - dif. por liq. con med. comerc. referencia`

- Se aprovecha para arreglar un test del `p48`.