### PR TITLE
Se han añadido los indicadores de ESIOS para el Precio horario AJOM del RDL 10/2022

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -259,3 +259,15 @@ class PriceMedioHorarioAJOSnocur(Indicator):
 
 class PriceMedioHorarioAJOScur(Indicator):
     path = 'indicators/1906'
+
+
+class PriceMedioHorarioAJOMtotal(Indicator):
+    path = 'indicators/1907'
+
+
+class PriceMedioHorarioAJOMnocur(Indicator):
+    path = 'indicators/1908'
+
+
+class PriceMedioHorarioAJOMcur(Indicator):
+    path = 'indicators/1909'

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -867,3 +867,39 @@ with description('Indicators file'):
             expect(data['indicator']['name']).to(
                 contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario - dif. por liq. con med. comerc. referencia')
             )
+        with it('Returns PriceMedioHorarioAJOMtotal instance'):
+            # 1907
+            e = Esios(self.token)
+            profile = PriceMedioHorarioAJOMtotal(e)
+            assert isinstance(profile, PriceMedioHorarioAJOMtotal)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Mecanismo de ajuste TOT_AJOM')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario ')
+            )
+        with it('Returns PriceMedioHorarioAJOMnocur instance'):
+            # 1908
+            e = Esios(self.token)
+            profile = PriceMedioHorarioAJOMnocur(e)
+            assert isinstance(profile, PriceMedioHorarioAJOMnocur)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Mecanismo de ajuste CLI_AJOM')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario contrataci\xf3n libre')
+            )
+        with it('Returns PriceMedioHorarioAJOMcur instance'):
+            # 1909
+            e = Esios(self.token)
+            profile = PriceMedioHorarioAJOMcur(e)
+            assert isinstance(profile, PriceMedioHorarioAJOMcur)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Mecanismo de ajuste CUR_AJOM')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario comercializadores de referencia')
+            )


### PR DESCRIPTION
Add the following `ESIOS` component:
- **1907**: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario`
- **1908**: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario contratación libre`
- **1909**: `Precio medio horario componente RD-L 10/2022 mercado diario e intradiario comercializadores de referencia`