### PR TITLE
Add x-api-key Header

### DIFF
--- a/.github/workflows/python3.6-app.yml
+++ b/.github/workflows/python3.6-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python3.6-app.yml
+++ b/.github/workflows/python3.6-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/esios/service.py
+++ b/esios/service.py
@@ -25,6 +25,7 @@ class Esios(base.Resource):
 
     def add_token(self, request):
         request.headers['Authorization'] = 'Token token="{0}"'.format(self.token)
+        request.headers['x-api-key'] = self.token
 
     def accepted_version(self, request):
         request.headers['Accept'] = (


### PR DESCRIPTION
We keep old header because production server of REE uses old header, but when deployed in production will use the new header

Closes #48 