### PR TITLE
Se ha añadido el indicadores de ESIOS para el precio marginal en el Servicio de Respuesta Activa de la Demanda

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -271,3 +271,7 @@ class PriceMedioHorarioAJOMnocur(Indicator):
 
 class PriceMedioHorarioAJOMcur(Indicator):
     path = 'indicators/1909'
+
+
+class PriceSRAD(Indicator):
+    path = 'indicators/1930'

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -903,3 +903,16 @@ with description('Indicators file'):
             expect(data['indicator']['name']).to(
                 contain(u'Precio medio horario componente RD-L 10/2022 mercado diario e intradiario comercializadores de referencia')
             )
+
+        with it('Returns PriceMedioHorarioAJOMcur instance'):
+            # 1930
+            e = Esios(self.token)
+            profile = PriceSRAD(e)
+            assert isinstance(profile, PriceSRAD)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Precio marginal en el servicio de respuesta activa de la demanda')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Precio marginal en el servicio de respuesta activa de la demanda')
+            )


### PR DESCRIPTION
Add the following `ESIOS` component:
- **1930**: `Precio marginal en el servicio de respuesta activa de la demanda`