### PR TITLE
Use requestes instead of urllib2 as default executor

### DIFF
--- a/esios/__init__.py
+++ b/esios/__init__.py
@@ -6,4 +6,6 @@ try:
 except Exception as e:
     VERSION = 'unknown'
 
+from libsaas.executors import requests_executor
+requests_executor.use()
 from .service import Esios


### PR DESCRIPTION
 Fix SSL negotiation on newest openssl versions