### PR TITLE
Nuevos indicadores de ESIOS (Enero 2025) 

### DIFF
--- a/.github/workflows/python2.7-app.yml
+++ b/.github/workflows/python2.7-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -35,8 +35,6 @@ class DemandaDiariaElectricaPeninsularPrevista(Indicator):
     path = 'indicators/460'
     time_agg = 'average'
 
-class DemandaDiariaElectricaPeninsularPrevistaQH(DemandaDiariaElectricaPeninsularPrevista):
-    time_trunc = 'fifteen_minutes'
 
 class ProfilePVPC20A(ProfilePVPC):
     path = 'indicators/526'
@@ -236,9 +234,6 @@ class mhpPowerFactorControl(Indicator):
 class DemandaDiariaElectricaPeninsularReal(Indicator):
     path = 'indicators/1293'
     time_agg = 'average'
-
-class DemandaDiariaElectricaPeninsularRealQH(DemandaDiariaElectricaPeninsularReal):
-    time_trunc = 'fifteen_minutes'
 
 class mhpEnergyBalanceFree(Indicator):
     path = 'indicators/1366'

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -6,6 +6,7 @@ from libsaas.services import base
 
 class Indicator(base.RESTResource):
     path = 'indicators'
+    time_agg = 'sum'
 
     @base.apimethod
     def get(self, start_date, end_date):
@@ -16,10 +17,11 @@ class Indicator(base.RESTResource):
         if end_date.tzinfo is None:
             raise Exception('End date must have time zone')
         time_trunc = 'hour'
+        time_agg = self.time_agg
         start_date = start_date.isoformat()
         end_date = end_date.isoformat()
         params = base.get_params(
-            ('start_date', 'end_date', 'time_trunc'), locals()
+            ('start_date', 'end_date', 'time_trunc', 'time_agg'), locals()
         )
         request = http.Request('GET', self.get_url(), params)
         return request, parsers.parse_json
@@ -30,6 +32,7 @@ class ProfilePVPC(Indicator):
 
 class DemandaDiariaElectricaPeninsularPrevista(Indicator):
     path = 'indicators/460'
+    time_agg = 'average'
 
 class ProfilePVPC20A(ProfilePVPC):
     path = 'indicators/526'
@@ -228,6 +231,7 @@ class mhpPowerFactorControl(Indicator):
 
 class DemandaDiariaElectricaPeninsularReal(Indicator):
     path = 'indicators/1293'
+    time_agg = 'average'
 
 class mhpEnergyBalanceFree(Indicator):
     path = 'indicators/1366'

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -6,6 +6,7 @@ from libsaas.services import base
 
 class Indicator(base.RESTResource):
     path = 'indicators'
+    time_trunc = 'hour'
     time_agg = 'sum'
 
     @base.apimethod
@@ -16,7 +17,7 @@ class Indicator(base.RESTResource):
             raise Exception('Start date must have time zone')
         if end_date.tzinfo is None:
             raise Exception('End date must have time zone')
-        time_trunc = 'hour'
+        time_trunc = self.time_trunc
         time_agg = self.time_agg
         start_date = start_date.isoformat()
         end_date = end_date.isoformat()

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -34,6 +34,9 @@ class DemandaDiariaElectricaPeninsularPrevista(Indicator):
     path = 'indicators/460'
     time_agg = 'average'
 
+class DemandaDiariaElectricaPeninsularPrevistaQH(DemandaDiariaElectricaPeninsularPrevista):
+    time_trunc = 'fifteen_minutes'
+
 class ProfilePVPC20A(ProfilePVPC):
     path = 'indicators/526'
 
@@ -232,6 +235,9 @@ class mhpPowerFactorControl(Indicator):
 class DemandaDiariaElectricaPeninsularReal(Indicator):
     path = 'indicators/1293'
     time_agg = 'average'
+
+class DemandaDiariaElectricaPeninsularRealQH(DemandaDiariaElectricaPeninsularReal):
+    time_trunc = 'fifteen_minutes'
 
 class mhpEnergyBalanceFree(Indicator):
     path = 'indicators/1366'

--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -28,6 +28,8 @@ class Indicator(base.RESTResource):
 class ProfilePVPC(Indicator):
     pass
 
+class DemandaDiariaElectricaPeninsularPrevista(Indicator):
+    path = 'indicators/460'
 
 class ProfilePVPC20A(ProfilePVPC):
     path = 'indicators/526'
@@ -224,6 +226,8 @@ class mhpPowerFactorControlFree(Indicator):
 class mhpPowerFactorControl(Indicator):
     path = 'indicators/1286'
 
+class DemandaDiariaElectricaPeninsularReal(Indicator):
+    path = 'indicators/1293'
 
 class mhpEnergyBalanceFree(Indicator):
     path = 'indicators/1366'

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -245,8 +245,19 @@ with description('Indicators file'):
         with it('Returns DemandaDiariaElectricaPeninsularPrevista instance'):
             # 460
             e = Esios(self.token)
+            # Hourly case
             profile = DemandaDiariaElectricaPeninsularPrevista(e)
             assert isinstance(profile, DemandaDiariaElectricaPeninsularPrevista)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Previsión diaria')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Previsión diaria de la demanda eléctrica peninsular')
+            )
+            # Quarter-Hourly case
+            profile = DemandaDiariaElectricaPeninsularPrevistaQH(e)
+            assert isinstance(profile, DemandaDiariaElectricaPeninsularPrevistaQH)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
                 equal(u'Previsión diaria')
@@ -788,8 +799,19 @@ with description('Indicators file'):
         with it('Returns DemandaDiariaElectricaPeninsularReal instance'):
             # 1293
             e = Esios(self.token)
+            # Hourly case
             profile = DemandaDiariaElectricaPeninsularReal(e)
             assert isinstance(profile, DemandaDiariaElectricaPeninsularReal)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Demanda real')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Demanda real')
+            )
+            # Quarter-Hourly case
+            profile = DemandaDiariaElectricaPeninsularRealQH(e)
+            assert isinstance(profile, DemandaDiariaElectricaPeninsularRealQH)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
                 equal(u'Demanda real')

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -241,6 +241,20 @@ with description('Indicators file'):
                 contain(u'Saldo horario neto de interconexión con Marruecos telemedidas')
             )
 
+    with context('DemandaDiariaElectricaPeninsularPrevista'):
+        with it('Returns DemandaDiariaElectricaPeninsularPrevista instance'):
+            # 460
+            e = Esios(self.token)
+            profile = DemandaDiariaElectricaPeninsularPrevista(e)
+            assert isinstance(profile, DemandaDiariaElectricaPeninsularPrevista)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Previsión diaria')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Previsión diaria de la demanda eléctrica peninsular')
+            )
+
     with context('PMDSNP'):
         with it('Returns pmd_snp instance'):
             # 573
@@ -770,6 +784,18 @@ with description('Indicators file'):
             )
             expect(data['indicator']['name']).to(
                 contain(u'Precio medio horario componente control factor potencia ')
+            )
+        with it('Returns DemandaDiariaElectricaPeninsularReal instance'):
+            # 1293
+            e = Esios(self.token)
+            profile = DemandaDiariaElectricaPeninsularReal(e)
+            assert isinstance(profile, DemandaDiariaElectricaPeninsularReal)
+            data = profile.get(self.start_date, self.end_date)
+            expect(data['indicator']['short_name']).to(
+                equal(u'Demanda real')
+            )
+            expect(data['indicator']['name']).to(
+                contain(u'Demanda real')
             )
         with it('Returns mhpEnergyBalanceFree instance'):
             #1366

--- a/spec/indicators_spec.py
+++ b/spec/indicators_spec.py
@@ -255,16 +255,6 @@ with description('Indicators file'):
             expect(data['indicator']['name']).to(
                 contain(u'Previsión diaria de la demanda eléctrica peninsular')
             )
-            # Quarter-Hourly case
-            profile = DemandaDiariaElectricaPeninsularPrevistaQH(e)
-            assert isinstance(profile, DemandaDiariaElectricaPeninsularPrevistaQH)
-            data = profile.get(self.start_date, self.end_date)
-            expect(data['indicator']['short_name']).to(
-                equal(u'Previsión diaria')
-            )
-            expect(data['indicator']['name']).to(
-                contain(u'Previsión diaria de la demanda eléctrica peninsular')
-            )
 
     with context('PMDSNP'):
         with it('Returns pmd_snp instance'):
@@ -802,16 +792,6 @@ with description('Indicators file'):
             # Hourly case
             profile = DemandaDiariaElectricaPeninsularReal(e)
             assert isinstance(profile, DemandaDiariaElectricaPeninsularReal)
-            data = profile.get(self.start_date, self.end_date)
-            expect(data['indicator']['short_name']).to(
-                equal(u'Demanda real')
-            )
-            expect(data['indicator']['name']).to(
-                contain(u'Demanda real')
-            )
-            # Quarter-Hourly case
-            profile = DemandaDiariaElectricaPeninsularRealQH(e)
-            assert isinstance(profile, DemandaDiariaElectricaPeninsularRealQH)
             data = profile.get(self.start_date, self.end_date)
             expect(data['indicator']['short_name']).to(
                 equal(u'Demanda real')


### PR DESCRIPTION
## Objetivos

- Añadir los siguientes indicadores a la librería:
  - `460`: `Previsión diaria de la demanda eléctrica peninsular`
  - `1293`: `Demanda real`

- Implementar indicadores.
- Implementar tests para los indicadores nuevos.

## Extra

- Actualizar batería de tests para `Python 2.7`.

- Añadidos los parámetros `time_agg` y `time_trunc` a los indicadores, con `sum` y `hour` como comportamiento por defecto.
