### PR TITLE
Modificar el agregador por defecto a avg

### DIFF
--- a/esios/indicators.py
+++ b/esios/indicators.py
@@ -7,7 +7,7 @@ from libsaas.services import base
 class Indicator(base.RESTResource):
     path = 'indicators'
     time_trunc = 'hour'
-    time_agg = 'sum'
+    time_agg = 'average'
 
     @staticmethod
     def validate_parameters(start_date, end_date, time_trunc, time_agg):


### PR DESCRIPTION
Ara que hi ha indicadors quart-horaris, esios encara que li demanis un valor horari retorna els valors quart-horaris. Per tant li demanem que ens faci la mitjana dels 4 valors quart-horaris